### PR TITLE
fall back to key non state

### DIFF
--- a/tamcolors/tam/tam_loop_io_handler.py
+++ b/tamcolors/tam/tam_loop_io_handler.py
@@ -143,6 +143,7 @@ class TAMLoopIOHandler:
             self._running = False
             if reset_colors_to_console_defaults:
                 self._io.reset_colors_to_console_defaults()
+            self._io.set_key_state_mode(False)
             self._io.done()
             self._key_loop_thread.join(timeout=5)
 


### PR DESCRIPTION
fall back to key non state.

this stops `non key state tamloops` from exiting on start if the last loop was `key state`